### PR TITLE
fix link to original Meilir Page-Jones article

### DIFF
--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -14,7 +14,7 @@
 		  	</div>
 		  	<div class="media-body">
 		   		<h4 class="media-heading">The Origins of Connascence</h4>
-				<p>Connascence is a software quality metric that attempts to measure coupling between entities. The term was used in a computer science context by Meilir Page-Jones in an article of the Communications of the ACM. The article can <a href="http://wiki.cfcl.com/pub/Projects/Connascence/Resources/p147-page-jones.pdf">still be found online</a>.</p>
+				<p>Connascence is a software quality metric that attempts to measure coupling between entities. The term was used in a computer science context by Meilir Page-Jones in his article, <a href="http://wiki.cfcl.com/pub/Projects/Connascence/Resources/p147-page-jones.pdf">Comparing techniques by means of encapsulation and connascence</a>, <em>Communications of the ACM</em> volume 35 issue 9 (September 1992).</p>
 				<p>In 1996, Meilir Page-Jones included a large section on connascence in his book "What every programmer should know about object-oriented design". The book can still be <a href="http://www.amazon.com/Every-Programmer-Should-Object-Oriented-Design/dp/0932633315" target="_blank">found on amazon.com</a>.
 				</p>
 		  	</div>

--- a/content/pages/about.html
+++ b/content/pages/about.html
@@ -14,7 +14,7 @@
 		  	</div>
 		  	<div class="media-body">
 		   		<h4 class="media-heading">The Origins of Connascence</h4>
-				<p>Connascence is a software quality metric that attempts to measure coupling between entities. The term was used in a computer science context by Meilir Page-Jones in an article of the Communications of the ACM. The article can <a href="http://cfcl.com/twiki6/pub/Projects/Connascence/Resources/p147-page-jones.pdf">still be found online</a>.</p>
+				<p>Connascence is a software quality metric that attempts to measure coupling between entities. The term was used in a computer science context by Meilir Page-Jones in an article of the Communications of the ACM. The article can <a href="http://wiki.cfcl.com/pub/Projects/Connascence/Resources/p147-page-jones.pdf">still be found online</a>.</p>
 				<p>In 1996, Meilir Page-Jones included a large section on connascence in his book "What every programmer should know about object-oriented design". The book can still be <a href="http://www.amazon.com/Every-Programmer-Should-Object-Oriented-Design/dp/0932633315" target="_blank">found on amazon.com</a>.
 				</p>
 		  	</div>


### PR DESCRIPTION
The current link is returning 403. I guess they moved their wiki and didn't bother with any redirects.
