### PR TITLE
Tabs to spaces in example for CoE

### DIFF
--- a/content/connascence-dynamic/connascence-of-execution.rst
+++ b/content/connascence-dynamic/connascence-of-execution.rst
@@ -11,10 +11,10 @@ Connascence of execution can also occur when using objects that encapsulate a st
 
 .. code-block:: python
 
-	email = Email()
-	email.setRecipient("foo@example.comp")
-	email.setSender("me@mydomain.com")
-	email.send()
-	email.setSubject("Hello World")
+    email = Email()
+    email.setRecipient("foo@example.comp")
+    email.setSender("me@mydomain.com")
+    email.send()
+    email.setSubject("Hello World")
 
 The last two lines show a trivial example of connascence of execution. The ``setSubject`` method cannot be called after the ``send`` method (at best it will do nothing). In this example the `locality <{filename}/properties/locality.rst>`_ of the coupling is very low, but cases where the locality is very high can be much harder to find and fix (consider, for example a scenario where the last two lines are called on separate threads).


### PR DESCRIPTION
All examples use spaces for indentation, except for the CoE example.
Translate tab to space for the CoE example.